### PR TITLE
ParseNewick Update, initialize_tree! & Additional Documentation

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -1,7 +1,14 @@
 # Basics
 
-This section provides an overview over the basic functionlities offered.
+This section provides an overview over the basic functionalities offered.
 
+When building / modifying trees with methods like *add_child!* or *insert_node!*, it might
+be necessarry to run *initialize_tree!* or *update_tree!* to ensure the nodes remain /are 
+initialized. 
+
+**WARNING**: Do not run *initialize_tree!* after changing a tree, if you rely on the num
+field of the nodes to identify them. The same applies to the method *number_nodes* that is
+called in *initalize_tree*.
 ## Basic Tree Functionalities
 
 ```@autodocs

--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -1,5 +1,9 @@
 # Tree Building & Transformations
 
+The tree building methods listed here ensure that the nodes of the tree(s) they build are
+fully initialized, i.e. they have a unique number, binary representation and a height. 
+Therefore there is no need to run *initialize_tree!* or *update_tree!* after running them.
+
 ## Matrix Representation
 
 ```@autodocs

--- a/docs/src/moves.md
+++ b/docs/src/moves.md
@@ -1,7 +1,17 @@
 # Moves
 
 There are several operations to change the topology or any of the branch lengths of a tree. 
-The different functions which are avialable in MCPhyloTree are listed here.
+The different functions which are available in MCPhyloTree are listed here.
+
+While the tree building methods in this package are generally built in a way that ensures 
+that the nodes of the tree are fully initialized, i.e. they have a unique number, binary 
+representation and a height, the move methods listed here do **not** automatically update
+these fields. After using these methods you might want to run *initialize_tree!* or 
+*update_tree!* to ensure the nodes remain / are initialized. 
+
+**WARNING**: Do not run *initialize_tree!* after changing a tree, if you rely on the num 
+field of the nodes to identify them. The same applies to the method *number_nodes* that is
+called in *initalize_tree*.
 
 ## Edge Length
 

--- a/src/Basics/Tree_Basics.jl
+++ b/src/Basics/Tree_Basics.jl
@@ -377,8 +377,8 @@ end # function number_nodes
 """
     initialize_tree!(root::FNode; height::Bool=true)
 
-This function initializes a tree, i.e. numbers its nodes ansd sets the binary + height 
-fields of its nodes.
+This function initializes a tree, i.e. numbers its nodes and sets the binary + height 
+fields.
 """
 function initialize_tree!(root::FNode; height::Bool=true)
     set_binary!(root)
@@ -389,12 +389,12 @@ end # initialize_tree
 """
     update_tree!(root::FNode)
 
-This function can be used to recompute the tree's binary and height values. 
-This might be necessary after adding/moving/removing nodes.
+This function can be used to recompute the tree's binary and height values. This might be 
+necessary after adding/moving/removing nodes.
 """
-function update_tree!(root::FNode)
+function update_tree!(root::FNode; height::Bool=true)
     set_binary!(root)
-    tree_height(root)
+    height && tree_height(root)
 end # update_tree
 
 """

--- a/src/Basics/Tree_Basics.jl
+++ b/src/Basics/Tree_Basics.jl
@@ -374,11 +374,28 @@ function number_nodes!(root::T)::Nothing  where T<:GeneralNode
     end # for
 end # function number_nodes
 
+"""
+    initialize_tree!(root::FNode; height::Bool=true)
+
+This function initializes a tree, i.e. numbers its nodes ansd sets the binary + height 
+fields of its nodes.
+"""
 function initialize_tree!(root::FNode; height::Bool=true)
     set_binary!(root)
     number_nodes!(root)
     height && tree_height(root)
 end # initialize_tree
+
+"""
+    update_tree!(root::FNode)
+
+This function can be used to recompute the tree's binary and height values. 
+This might be necessary after adding/moving/removing nodes.
+"""
+function update_tree!(root::FNode)
+    set_binary!(root)
+    tree_height(root)
+end # update_tree
 
 """
     random_node(root::T)::T  where T<:GeneralNode

--- a/src/Basics/Tree_Basics.jl
+++ b/src/Basics/Tree_Basics.jl
@@ -308,7 +308,7 @@ function path_length(ancestor::T, descendant::T)::Float64  where T<:GeneralNode
         descendant = get_mother(descendant)
     end # while
     return l
-end #function path_length
+end # function path_length
 
 
 """
@@ -372,9 +372,13 @@ function number_nodes!(root::T)::Nothing  where T<:GeneralNode
             running += 1
         end
     end # for
-end # fuction number_nodes
+end # function number_nodes
 
-
+function initialize_tree!(root::FNode; height::Bool=true)
+    set_binary!(root)
+    number_nodes!(root)
+    height && tree_height(root)
+end # initialize_tree
 
 """
     random_node(root::T)::T  where T<:GeneralNode

--- a/src/Building/ParseNewick.jl
+++ b/src/Building/ParseNewick.jl
@@ -142,8 +142,7 @@ function ParseNewick(s::String)::Union{FNode, Array{FNode,1}}
     # check if the input string is a newick string & parse + return it if so
     if is_valid_newick_string(s) 
         tree::FNode = parsing_newick_string(s)
-        set_binary!(tree)
-        number_nodes!(tree)
+        initialize_tree!(tree)
         return tree
     end # if
     
@@ -165,8 +164,7 @@ function ParseNewick(s::String)::Union{FNode, Array{FNode,1}}
             throw("$content is not correctly formatted!")
         end # if
         tree = parsing_newick_string(string(content))
-        set_binary!(tree)
-        number_nodes!(tree)
+        initialize_tree!(tree)
         push!(list_of_newicks, tree)
     end # for
     list_of_newicks

--- a/src/Building/ParseNewick.jl
+++ b/src/Building/ParseNewick.jl
@@ -13,7 +13,7 @@ function is_valid_newick_string(newick::String) # TODO: possibly not necessary; 
             if letter == '('
                 bracket_level += 1
             elseif letter == ')'
-                    bracket_level -= 1
+                bracket_level -= 1
             end # elseif
         end # for
         if bracket_level != 0
@@ -123,26 +123,40 @@ function Sibling_parse(childrenstring::String) # returns list of children of a n
     return child_list
 end # function
 
-
 """
-    ParseNewick(filename::String)::Array{GeneralNode, 1}
+    ParseNewick(s::String)::Union{GeneralNode, Array{GeneralNode, 1}}
 
-This function takes a filename as a String, and returns an array of trees(represented as Node objects).
-The file should solely consist of newick tree representations, separated by line.
-The function checks for proper newick formatting, and will return an error if the file is
-incorrectly formatted.
+This function takes a string - either a filename or a newick string - and reads the file /
+string to return an array of trees (represented as Node objects). The file should solely 
+consist of newick tree representations, separated by line. The function checks for proper 
+newick formatting, and will return an error if the string / file is incorrectly formatted.
 
-Returns an Array of Nodes; each Node is the root of the tree represented by a newick string in the file.
+Mewick string input: Returns the root of the tree represented by the newick string.
+Filename input: Returns an Array of Nodes; each Node is the root of the tree represented by
+a newick string in the file.
 
-* `filename` : name of file containing newick strings to parse.
+* `s` : newick string or name of file containing newick strings to parse.
 """
-function ParseNewick(filename::String)::Array{GeneralNode,1}
+function ParseNewick(s::String)::Union{FNode, Array{FNode,1}}
     
-    list_of_trees = open(filename, "r") do file
-        readlines(file)
-    end
+    # check if the input string is a newick string & parse + return it if so
+    if is_valid_newick_string(s) 
+        tree::FNode = parsing_newick_string(s)
+        set_binary!(tree)
+        number_nodes!(tree)
+        return tree
+    end # if
     
-    list_of_newicks = GeneralNode[]
+    list_of_trees::Vector{String} = []
+    try
+        list_of_trees = open(s, "r") do file
+            readlines(file)
+        end # do
+    catch
+        throw(ErrorException("Input must be valid newick string or file name. Check path to file & check validity of newick string by running is_valid_newick_string(string)"))
+    end # try/catch
+        
+    list_of_newicks = FNode[]
     for content in list_of_trees
         if content == ""
             continue
@@ -156,4 +170,4 @@ function ParseNewick(filename::String)::Array{GeneralNode,1}
         push!(list_of_newicks, tree)
     end # for
     list_of_newicks
-end
+end # ParseNewick

--- a/src/Building/Tree_Building.jl
+++ b/src/Building/Tree_Building.jl
@@ -61,8 +61,7 @@ function create_tree_from_leaves(leaf_nodes::Vector{String}, rooted::Bool=false)
     add_child!(root, rchild)
     add_child!(root, mchild)
 
-    set_binary!(root)
-    number_nodes!(root)
+    initialize_tree!(root)
 
     return root
 end # function create_tree_from_leaves
@@ -104,7 +103,6 @@ function from_df(df::Array{Float64,2}, name_list::Vector{String})::FNode
     node::FNode = node_list[i]
 
     # do some bookeeping here and set the binary representation of the nodes
-    set_binary!(node)
-    number_nodes!(node)
+    initialize_tree!(node)
     return node
 end # function from_df

--- a/src/Building/Tree_Clustering.jl
+++ b/src/Building/Tree_Clustering.jl
@@ -81,8 +81,7 @@ function upgma_int(
         # return (root) node when algorithm is finished
         n -= 1
         if n == 1
-            set_binary!(new_cluster)
-            number_nodes!(new_cluster)
+            initialize_tree!(new_cluster)
             return new_cluster
         end
         # initalize cluster weights
@@ -234,8 +233,7 @@ function neighbor_joining_int(dm::Array{Float64,2}, leaves::Vector{FNode})
             final_leaf.inc_length = dm[1, 2]
             # add third child to new node created previously
             add_child!(new_node, final_leaf)
-            set_binary!(new_node)
-            number_nodes!(new_node)
+            initialize_tree!(new_node, height=false)
             return new_node
         end # end if
     end # end while

--- a/src/Building/Tree_Consensus.jl
+++ b/src/Building/Tree_Consensus.jl
@@ -25,7 +25,9 @@ Jesper Jansson, Chuanqi Shen, and Wing-Kin Sung. 2016. Improved algorithms
 for constructing consensustrees. J. ACM 63, 3, Article 28 (June 2016), 24 pages
 https://dl.acm.org/doi/pdf/10.1145/2925985
 """
-function majority_consensus_tree(trees::Vector{T}, percentage::Float64=0.5)::T where T<:GeneralNode
+function majority_consensus_tree(trees::Vector{T}, percentage::Float64=0.5
+         )::T where T<:GeneralNode
+
     merged_tree = deepcopy(trees[1])
     check_leafsets(trees)
     nodes = post_order(merged_tree)
@@ -48,8 +50,7 @@ function majority_consensus_tree(trees::Vector{T}, percentage::Float64=0.5)::T w
                 end # if
             end # else
         end # for
-        set_binary!(merged_tree)
-        number_nodes!(merged_tree)
+        initialize_tree!(merged_tree, height=false)
         compatible_tree = one_way_compatible(tree, merged_tree)
         inserted_nodes = merge_trees!(compatible_tree, merged_tree)
         # intialize counts for the new nodes
@@ -182,9 +183,11 @@ function greedy_consensus_tree(trees::Vector{T})::T where T <: GeneralNode
                 num[node] = [sum([num[child][1] for child in node.children])]
                 n_leaves = 0
                 for child in node.children
-                        n_leaves += num[child][2]
+                    length(num[child]) != 2 && show(num)
+                    n_leaves += num[child][2]
                 end # for
                 push!(num[node], n_leaves)
+                length(num[node]) != 2 && show(num)
                 children = Vector{T}()
                 if num[node][1] == cluster_length
                     insert = true
@@ -396,8 +399,7 @@ function one_way_compatible(ref_tree::T, tree::T)::T where T <: GeneralNode
             delete_node!(node)
         end # if
     end # for
-    set_binary!(ref_tree_copy)
-    number_nodes!(ref_tree_copy)
+    initialize_tree!(ref_tree_copy, height=false)
     return ref_tree_copy
 end # function one_way_compatible
 
@@ -589,8 +591,8 @@ end # get_leaf_ranks
 Helper function to order a tree based on cluster indeces and return the leaves
 of the ordered tree
 """
-function order_tree!(root::T, cluster_start_indeces::Dict{T, Int64},
-                     leaves=Vector{T}())::Vector{T} where T<:GeneralNode
+function order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vector{T}()
+                    )::Vector{T} where T<:GeneralNode
 
     sort!(root.children, by = child -> cluster_start_indeces[child],
           alg=InsertionSort)

--- a/src/Building/Tree_Consensus.jl
+++ b/src/Building/Tree_Consensus.jl
@@ -386,7 +386,7 @@ function one_way_compatible(ref_tree::T, tree::T)::T where T <: GeneralNode
     ref_tree_copy = deepcopy(ref_tree)
     ref_nodes = post_order(ref_tree_copy)
     cluster_start_indeces = get_cluster_start_indeces(ref_nodes, tree)
-    leaves::Vector{T} = order_tree!(tree, cluster_start_indeces)
+    leaves::Vector{T} = order_tree!(tree, cluster_start_indeces; height=false)
     leaf_ranks_reverse = Dict(node.name => ind for (ind, node) in enumerate(leaves))
     xleft_dict, xright_dict = depth_dicts(leaves)
     marked_nodes = Dict{Int64, Bool}()
@@ -421,7 +421,7 @@ of nodes that were added.
 function merge_trees!(ref_tree::T, tree::T)::Vector{T} where T<:GeneralNode
     ref_nodes = post_order(ref_tree)
     cluster_start_indeces = get_cluster_start_indeces(ref_nodes, tree)
-    leaves::Vector{T} = order_tree!(tree, cluster_start_indeces)
+    leaves::Vector{T} = order_tree!(tree, cluster_start_indeces; height=false)
     leaf_ranks_reverse = Dict(node.name => ind for (ind, node) in enumerate(leaves))
     xleft_dict, xright_dict = depth_dicts(leaves)
     inserted_nodes = Vector{T}()
@@ -584,15 +584,15 @@ end # get_leaf_ranks
 
 
 """
-    order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vector{T}())
-        ::Vector{T} where T<:GeneralNode
+    order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vector{T}();
+                height=true)::Vector{T} where T<:GeneralNode
 
 --- INTERNAL ---
 Helper function to order a tree based on cluster indeces and return the leaves
 of the ordered tree
 """
-function order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vector{T}()
-                    )::Vector{T} where T<:GeneralNode
+function order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vector{T}();
+                     height=true)::Vector{T} where T<:GeneralNode
 
     sort!(root.children, by = child -> cluster_start_indeces[child],
           alg=InsertionSort)
@@ -600,10 +600,10 @@ function order_tree!(root::T, cluster_start_indeces::Dict{T, Int64}, leaves=Vect
         if child.nchild == 0
             push!(leaves, child)
         else
-            order_tree!(child, cluster_start_indeces, leaves)
+            order_tree!(child, cluster_start_indeces, leaves; height=false)
         end # if/else
     end # for
-    set_binary!(root)
+    update_tree!(root; height=height)
     return leaves
 end # order_tree!
 

--- a/src/Building/Tree_Ladderizing.jl
+++ b/src/Building/Tree_Ladderizing.jl
@@ -1,6 +1,5 @@
 """
-    ladderize_tree!(root::T, ascending::Bool=true)
-        ::Nothing where T<:GeneralNode
+    ladderize_tree!(root::T, ascending::Bool=true) where T<:GeneralNode
 
 This function ladderizes a tree inplace, i.e. sorts the nodes on all levels by the count
 of their descendants.
@@ -22,6 +21,7 @@ function ladderize_tree!(root::T, ascending::Bool=true) where T<:GeneralNode
     for child in root.children
         ladderize_tree!(child, ascending)
     end
+    set_binary!(root)
 end
 
 

--- a/src/Distance/Tree_Distance.jl
+++ b/src/Distance/Tree_Distance.jl
@@ -13,10 +13,8 @@ Returns result of algorithm as integer.
 * `tree2` : tree used to determine RF distance.
 """
 function RF(tree1::T, tree2::T)::Int64 where T <: GeneralNode
-    set_binary!(tree1)
-    set_binary!(tree2)
-    number_nodes!(tree1)
-    number_nodes!(tree2)
+    initialize_tree!(tree1, height=false)
+    initialize_tree!(tree2, height=false)
     r, _ = RF_int(tree1, tree2)
     return r
 end
@@ -41,10 +39,8 @@ Returns result of algorithm as integer.
 * `tree2` : tree used to determine RF distance.
 """
 function RF_weighted(tree1::T, tree2::T)::Float64 where T <: GeneralNode
-    set_binary!(tree1)
-    set_binary!(tree2)
-    number_nodes!(tree1)
-    number_nodes!(tree2)
+    initialize_tree!(tree1, height=false)
+    initialize_tree!(tree2, height=false)
     rf, l1 = RF_int(tree1, tree2)
     rf / l1
 end

--- a/src/Moves/EdgeLength.jl
+++ b/src/Moves/EdgeLength.jl
@@ -4,7 +4,7 @@
 """
     slide!(root::T) where T<:GeneralNode
 
-This functin performs a slide move on an intermediate node. The node is moved
+This function performs a slide move on an intermediate node. The node is moved
 upwards or downwards on the path specified by its mother and one of its
 daughters.
 
@@ -36,7 +36,7 @@ end # function slide!
 """
     slide(root::T)::T where T<:GeneralNode
 
-This functin performs a slide move on an intermediate node. The node is moved
+This function performs a slide move on an intermediate node. The node is moved
 upwards or downwards on the path specified by its mother and one of its
 daughters.
 
@@ -101,11 +101,11 @@ end
 Change the incoming length of node1 and node2 while keeping their combined length
 constant.
 
-* `node1` : Node whose inc_length will be modified; this node's inc_length will be the total inc_length of both nodes, times proportion.
+* `node1` : Node whose inc\\_length will be modified; this node's inc\\_length will be the total inc\\_length of both nodes, times proportion.
 
-* `node2` : Node whose inc_length will be modified; this node's inc_length will be the remainder of total - the new inc_length value of node1.
+* `node2` : Node whose inc\\_length will be modified; this node's inc\\_length will be the remainder of total - the new inc\\_length value of node1.
 
-* `proportion` : Float64, determines proportion of the inc_length of both nodes assigned to node1.
+* `proportion` : Float64, determines proportion of the inc\\_length of both nodes assigned to node1.
 """
 function move!(node1::T, node2::T, proportion::Float64) where {T<:GeneralNode}
     total::Float64 = node1.inc_length + node2.inc_length

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,25 +1,25 @@
 
 @testset "add_child!" begin
-    tree = parsing_newick_string("(A,B,(C,D,E)F)G;")
+    tree = ParseNewick("(A,B,(C,D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
-    to_add = parsing_newick_string("no_name;")
+    to_add = ParseNewick("no_name;")
     root = find_by_name(tree,"G")
     add_child!(root,to_add)
     @test root.children[end].name == "no_name"
     @test length(post_order(tree))==8
 
-    tree = parsing_newick_string("(A,B,(C,D,E)F)G;")
+    tree = ParseNewick("(A,B,(C,D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
-    to_add = parsing_newick_string("no_name;")
+    to_add = ParseNewick("no_name;")
     leaf = find_by_name(tree,"D")
     add_child!(leaf,to_add)
     @test leaf.children[end].name == "no_name"
     @test length(post_order(tree))==8
 
 
-    tree = parsing_newick_string("(A,B,(C,D,E)F)G;")
+    tree = ParseNewick("(A,B,(C,D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
-    to_add = parsing_newick_string("no_name;")
+    to_add = ParseNewick("no_name;")
     mid = find_by_name(tree,"F")
     add_child!(mid,to_add)
 
@@ -28,7 +28,7 @@
 end
 
 @testset "remove_child!" begin
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     remove_child!(mother,true)
@@ -36,7 +36,7 @@ end
     @test mother.children[1].name == "B"
     @test length(post_order(tree)) == 6
 
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     remove_child!(mother,false)
@@ -44,7 +44,7 @@ end
     @test mother.children[1].name == "A"
     @test length(post_order(tree)) == 6
 
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     remove_child!(tree,true)
     @test tree.children[1].name == "F"
@@ -54,7 +54,7 @@ end
 end
 
 @testset "remove_child! by node" begin
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     to_remove = find_by_name(tree,"A")
@@ -63,7 +63,7 @@ end
     @test mother.children[1].name == "B"
     @test length(post_order(tree)) == 6
 
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     to_remove = find_by_name(tree,"B")
@@ -72,7 +72,7 @@ end
     @test mother.children[1].name == "A"
     @test length(post_order(tree)) == 6
 
-    tree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.number_nodes!(tree)
     to_remove = find_by_name(tree,"C")
     remove_child!(tree,to_remove)
@@ -82,24 +82,24 @@ end
 end
 
 @testset "tree_length" begin
-    tree = parsing_newick_string("((A:5,B:5)C:3.5,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:3.5,(D:5,E:5)F:5)G:5;")
     @test tree_length(tree) == 28.5
 end
 
 @testset "tree_height" begin
-    tree = parsing_newick_string("((A:5,B:5)C:3.5,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:3.5,(D:5,E:5)F:5)G:5;")
     @test tree_height(tree) == 10.0
 end
 
 @testset "node_height" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     node_height(tree)
     @test tree.height == 14.0
 end
 
 @testset "node_age" begin
-    tree = parsing_newick_string("(((A:8,B:5)F:2,C:10)G:1,(D:12,E:4)H:3)R:1;")
+    tree = ParseNewick("(((A:8,B:5)F:2,C:10)G:1,(D:12,E:4)H:3)R:1;")
     MCPhyloTree.tree_height(tree)
     MCPhyloTree.tree_length(tree)
     MCPhyloTree.number_nodes!(tree)
@@ -114,7 +114,7 @@ end
 end 
 
 @testset "node_depth" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
@@ -125,7 +125,7 @@ end
 end
 
 @testset "get_path" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
@@ -134,7 +134,7 @@ end
 end
 
 @testset "path_length" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
@@ -143,7 +143,7 @@ end
 end
 
 @testset "get_sister" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
@@ -155,7 +155,7 @@ end
 end
 
 @testset "set_binary!" begin
-    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
@@ -166,7 +166,7 @@ end
 end
 
 @testset "number_nodes!" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
@@ -177,7 +177,7 @@ end
 end
 
 @testset "blv" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     @test get_branchlength_vector(tree) == [5.0, 5.0, 5.0, 5.0, 9.0, 5.0]
@@ -187,7 +187,7 @@ end
 end
 
 @testset "internal_external" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     map = MCPhyloTree.internal_external_map(tree)
@@ -196,22 +196,19 @@ end
 end
 
 @testset "check_binary" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     @test check_binary(tree)
-    tree = parsing_newick_string("((B:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5)C:9,(D:5,E:5)F:5)G:5;")
     @test !check_binary(tree)
-    tree = parsing_newick_string("((B:5,A:5,X:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5,X:5)C:9,(D:5,E:5)F:5)G:5;")
     @test !check_binary(tree)
 end
 
-
-
-
 @testset "insert_node!" begin
-    tree = parsing_newick_string("(A,B,(C,D,E)F)G;")
-    insert_tree = parsing_newick_string("(A,B,((C,D,E)no_name)F)G;")
+    tree = ParseNewick("(A,B,(C,D,E)F)G;")
+    insert_tree = ParseNewick("(A,B,((C,D,E)no_name)F)G;")
     insert_tree_newick = newick(insert_tree)
-    insert_tree2 = parsing_newick_string("(A,B,(((C,D)no_name,E)no_name)F)G;")
+    insert_tree2 = ParseNewick("(A,B,(((C,D)no_name,E)no_name)F)G;")
     insert_tree_newick2 = newick(insert_tree2)
     MCPhyloTree.number_nodes!(tree)
 
@@ -231,11 +228,11 @@ end
  end
 
 @testset "delete_node!" begin
-    tree = parsing_newick_string("(A,B,(C,D)E)F;")
+    tree = ParseNewick("(A,B,(C,D)E)F;")
     MCPhyloTree.number_nodes!(tree)
-    remove_tree = parsing_newick_string("(A,B,C,D)F;")
+    remove_tree = ParseNewick("(A,B,C,D)F;")
     remove_tree_newick = newick(remove_tree)
-    remove_tree2 = parsing_newick_string("(B,C,D)F;")
+    remove_tree2 = ParseNewick("(B,C,D)F;")
     remove_tree2_newick = newick(remove_tree2)
 
     delete_node!(find_by_name(tree, "E"))
@@ -246,7 +243,7 @@ end
 end
 
 @testset "find_lca" begin
-    tree = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+    tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
     MCPhyloTree.set_binary!(tree)
 
     @testset "find_lca by name" begin
@@ -271,11 +268,11 @@ end
 end
 
 @testset "check_leafsets" begin
-    tree1 = parsing_newick_string("(((A,B),C),(D,E))")
-    tree2 = parsing_newick_string("((A,C),(B,D,E))")
-    tree3 = parsing_newick_string("(((G,C),A),D,F)")
-    tree4 = parsing_newick_string("(((B,C),A),D,E)")
-    tree5 = parsing_newick_string("(((B,C),A),D,F)")
+    tree1 = ParseNewick("(((A,B),C),(D,E));")
+    tree2 = ParseNewick("((A,C),(B,D,E));")
+    tree3 = ParseNewick("(((G,C),A),D,F);")
+    tree4 = ParseNewick("(((B,C),A),D,E);")
+    tree5 = ParseNewick("(((B,C),A),D,F);")
 
     trees = [tree1, tree2, tree3, tree4, tree5]
     MCPhyloTree.number_nodes!.(trees)
@@ -285,7 +282,7 @@ end
 end
 
 @testset "mother" begin
-    tree1 = parsing_newick_string("(((A,B)F,C)G,(D,E)H)R;")
+    tree1 = ParseNewick("(((A,B)F,C)G,(D,E)H)R;")
     MCPhyloTree.number_nodes!(tree1)
     MCPhyloTree.set_binary!(tree1)
     @test_throws ArgumentError get_mother(find_by_name(tree1, "R"))
@@ -293,7 +290,7 @@ end
 end
 
 @testset "force_ultrametric" begin
-    tree1 = parsing_newick_string("(((A:5,B:5)F:5,C:5)G:5,(D:5,E:5)H:5)R:5;")
+    tree1 = ParseNewick("(((A:5,B:5)F:5,C:5)G:5,(D:5,E:5)H:5)R:5;")
     MCPhyloTree.number_nodes!(tree1)
     MCPhyloTree.set_binary!(tree1)
     MCPhyloTree.force_ultrametric!(tree1)
@@ -303,9 +300,9 @@ end
 end
 
 @testset "ascii" begin
-    tree = parsing_newick_string("(A,B)C;")
-    singletree = parsing_newick_string("(((A,B)C)D,(E)F,G)H;")
-    bigtree = parsing_newick_string("((A,B)C,(D,E)F)G;")
+    tree = ParseNewick("(A,B)C;")
+    singletree = ParseNewick("(((A,B)C)D,(E)F,G)H;")
+    bigtree = ParseNewick("((A,B)C,(D,E)F)G;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(bigtree)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,7 +1,6 @@
 
 @testset "add_child!" begin
     tree = ParseNewick("(A,B,(C,D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     to_add = ParseNewick("no_name;")
     root = find_by_name(tree,"G")
     add_child!(root,to_add)
@@ -9,7 +8,6 @@
     @test length(post_order(tree))==8
 
     tree = ParseNewick("(A,B,(C,D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     to_add = ParseNewick("no_name;")
     leaf = find_by_name(tree,"D")
     add_child!(leaf,to_add)
@@ -18,7 +16,6 @@
 
 
     tree = ParseNewick("(A,B,(C,D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     to_add = ParseNewick("no_name;")
     mid = find_by_name(tree,"F")
     add_child!(mid,to_add)
@@ -29,7 +26,6 @@ end
 
 @testset "remove_child!" begin
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     remove_child!(mother,true)
     @test length(mother.children) == 1
@@ -37,7 +33,6 @@ end
     @test length(post_order(tree)) == 6
 
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     remove_child!(mother,false)
     @test length(mother.children) == 1
@@ -45,7 +40,6 @@ end
     @test length(post_order(tree)) == 6
 
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     remove_child!(tree,true)
     @test tree.children[1].name == "F"
     @test length(tree.children) == 1
@@ -55,7 +49,6 @@ end
 
 @testset "remove_child! by node" begin
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     to_remove = find_by_name(tree,"A")
     remove_child!(mother,to_remove)
@@ -64,7 +57,6 @@ end
     @test length(post_order(tree)) == 6
 
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     mother = find_by_name(tree,"C")
     to_remove = find_by_name(tree,"B")
     remove_child!(mother,to_remove)
@@ -73,7 +65,6 @@ end
     @test length(post_order(tree)) == 6
 
     tree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.number_nodes!(tree)
     to_remove = find_by_name(tree,"C")
     remove_child!(tree,to_remove)
     @test tree.children[1].name == "F"
@@ -93,17 +84,12 @@ end
 
 @testset "node_height" begin
     tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
     node_height(tree)
     @test tree.height == 14.0
 end
 
 @testset "node_age" begin
     tree = ParseNewick("(((A:8,B:5)F:2,C:10)G:1,(D:12,E:4)H:3)R:1;")
-    MCPhyloTree.tree_height(tree)
-    MCPhyloTree.tree_length(tree)
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     leaf = find_by_name(tree, "A")
     internal_node = find_by_name(tree, "F")
     furthest_leaf = find_by_name(tree, "D")
@@ -115,8 +101,6 @@ end
 
 @testset "node_depth" begin
     tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree, "A")
     @test node_depth(tree) == 0
@@ -126,7 +110,6 @@ end
 
 @testset "get_path" begin
     tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
     @test get_path(tree,mid) == [6]
@@ -135,7 +118,6 @@ end
 
 @testset "path_length" begin
     tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
     @test path_length(tree,mid) == 5.0
@@ -144,8 +126,6 @@ end
 
 @testset "get_sister" begin
     tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
     leafresult = get_sister(leaf)
@@ -155,8 +135,7 @@ end
 end
 
 @testset "set_binary!" begin
-    tree = ParseNewick("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
+    tree = parsing_newick_string("((A:5,B:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
@@ -166,9 +145,8 @@ end
 end
 
 @testset "number_nodes!" begin
-    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     mid = find_by_name(tree,"F")
     leaf = find_by_name(tree,"A")
     @test tree.num == 7
@@ -178,8 +156,6 @@ end
 
 @testset "blv" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     @test get_branchlength_vector(tree) == [5.0, 5.0, 5.0, 5.0, 9.0, 5.0]
     set_branchlength_vector!(tree,[1.0,1.0,1.0,1.0,1.0,1.0])
     @test get_branchlength_vector(tree) == [1.0,1.0,1.0,1.0,1.0,1.0]
@@ -188,8 +164,6 @@ end
 
 @testset "internal_external" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     map = MCPhyloTree.internal_external_map(tree)
     @test map == [0, 0, 0, 0, 1, 1]
     @test MCPhyloTree.internal_external(tree) == [0, 0, 0, 0, 1, 1]
@@ -210,7 +184,6 @@ end
     insert_tree_newick = newick(insert_tree)
     insert_tree2 = ParseNewick("(A,B,(((C,D)no_name,E)no_name)F)G;")
     insert_tree_newick2 = newick(insert_tree2)
-    MCPhyloTree.number_nodes!(tree)
 
     children = [find_by_name(tree, "C"), find_by_name(tree, "D"),
                 find_by_name(tree, "E")]
@@ -229,7 +202,6 @@ end
 
 @testset "delete_node!" begin
     tree = ParseNewick("(A,B,(C,D)E)F;")
-    MCPhyloTree.number_nodes!(tree)
     remove_tree = ParseNewick("(A,B,C,D)F;")
     remove_tree_newick = newick(remove_tree)
     remove_tree2 = ParseNewick("(B,C,D)F;")
@@ -244,7 +216,6 @@ end
 
 @testset "find_lca" begin
     tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
-    MCPhyloTree.set_binary!(tree)
 
     @testset "find_lca by name" begin
         @test find_lca(tree, ["A","C"]) == tree
@@ -275,24 +246,18 @@ end
     tree5 = ParseNewick("(((B,C),A),D,F);")
 
     trees = [tree1, tree2, tree3, tree4, tree5]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
 
     @test_throws ArgumentError check_leafsets(trees)
 end
 
 @testset "mother" begin
     tree1 = ParseNewick("(((A,B)F,C)G,(D,E)H)R;")
-    MCPhyloTree.number_nodes!(tree1)
-    MCPhyloTree.set_binary!(tree1)
     @test_throws ArgumentError get_mother(find_by_name(tree1, "R"))
     @test get_mother(find_by_name(tree1, "A")).name == "F"
 end
 
 @testset "force_ultrametric" begin
     tree1 = ParseNewick("(((A:5,B:5)F:5,C:5)G:5,(D:5,E:5)H:5)R:5;")
-    MCPhyloTree.number_nodes!(tree1)
-    MCPhyloTree.set_binary!(tree1)
     MCPhyloTree.force_ultrametric!(tree1)
     for x in get_leaves(tree1)
         @test path_length(tree1,x) == 15.0
@@ -303,12 +268,6 @@ end
     tree = ParseNewick("(A,B)C;")
     singletree = ParseNewick("(((A,B)C)D,(E)F,G)H;")
     bigtree = ParseNewick("((A,B)C,(D,E)F)G;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(bigtree)
-    MCPhyloTree.number_nodes!(bigtree)
-    MCPhyloTree.set_binary!(singletree)
-    MCPhyloTree.number_nodes!(singletree)
     lines,_ = MCPhyloTree.ascii(tree)
     biglines,_ = MCPhyloTree.ascii(bigtree)
     singlelines,_ = MCPhyloTree.ascii(singletree)

--- a/test/building.jl
+++ b/test/building.jl
@@ -9,8 +9,6 @@
     rt = upgma(D, ["a", "b", "c", "d", "e"])
     rt2 = upgma(D)
     gst = ParseNewick("(((a,b)u,e)v,(c,d)w)r;")
-    MCPhyloTree.number_nodes!(gst)
-    MCPhyloTree.set_binary!(gst)
 
     @test RF(rt, gst) == 0
     @test tree_height(rt) == 16.5
@@ -21,8 +19,6 @@ end
     D = [0.0 3.0 14.0 12.0; 3 0 13 11; 14.0 13.0 0.0 4; 12.0 11.0 4.0 0]
     rt = neighbor_joining(D, ["a", "b", "d", "e"])
     gst = ParseNewick("((a,b)c,d,e);")
-    MCPhyloTree.number_nodes!(gst)
-    MCPhyloTree.set_binary!(gst)
     @test RF(rt, gst) == 0
     @test tree_length(rt) == 16
 end
@@ -34,8 +30,6 @@ end
 
 @testset "to_covariance" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     @test to_covariance(tree) ==
           [14.0 9.0 0.0 0.0; 9.0 14.0 0.0 0.0; 0.0 0.0 10.0 5.0; 0.0 0.0 5.0 10.0]
 end
@@ -49,8 +43,6 @@ end
 
 @testset "to_df" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     target_arr = [
         0.0 0.0 0.0 0.0 0.0 0.0 0.0
         0.0 0.0 0.0 0.0 0.0 0.0 0.0
@@ -69,8 +61,6 @@ end
 
 @testset "from_df" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     target_arr = [
         0.0 0.0 0.0 0.0 0.0 0.0 0.0
         0.0 0.0 0.0 0.0 0.0 0.0 0.0
@@ -88,8 +78,6 @@ end
 
 @testset "leave_incidence_matrix" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     lm = leave_incidence_matrix(tree)
     target = [
         0.0 1.0 0.0 0.0 1.0 0.0

--- a/test/building.jl
+++ b/test/building.jl
@@ -8,7 +8,7 @@
     ]
     rt = upgma(D, ["a", "b", "c", "d", "e"])
     rt2 = upgma(D)
-    gst = parsing_newick_string("(((a,b)u,e)v,(c,d)w)r;")
+    gst = ParseNewick("(((a,b)u,e)v,(c,d)w)r;")
     MCPhyloTree.number_nodes!(gst)
     MCPhyloTree.set_binary!(gst)
 
@@ -20,7 +20,7 @@ end
 @testset "NJ" begin
     D = [0.0 3.0 14.0 12.0; 3 0 13 11; 14.0 13.0 0.0 4; 12.0 11.0 4.0 0]
     rt = neighbor_joining(D, ["a", "b", "d", "e"])
-    gst = parsing_newick_string("((a,b)c,d,e);")
+    gst = ParseNewick("((a,b)c,d,e);")
     MCPhyloTree.number_nodes!(gst)
     MCPhyloTree.set_binary!(gst)
     @test RF(rt, gst) == 0
@@ -28,12 +28,12 @@ end
 end
 
 @testset "newick" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     @test newick(tree) == "((B:5.0,A:5.0)C:9.0,(D:5.0,E:5.0)F:5.0)G:5.0;"
 end
 
 @testset "to_covariance" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     @test to_covariance(tree) ==
@@ -41,14 +41,14 @@ end
 end
 
 @testset "ladderize" begin
-    tree = parsing_newick_string("((B:5,A:5,X,Y,Z)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5,X,Y,Z)C:9,(D:5,E:5)F:5)G:5;")
     ladder = ladderize_tree(tree, true)
     @test newick(ladder) ==
           "((D:5.0,E:5.0)F:5.0,(B:5.0,A:5.0,X:1.0,Y:1.0,Z:1.0)C:9.0)G:5.0;"
 end
 
 @testset "to_df" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     target_arr = [
@@ -68,7 +68,7 @@ end
 
 
 @testset "from_df" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     target_arr = [
@@ -87,7 +87,7 @@ end
 
 
 @testset "leave_incidence_matrix" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     lm = leave_incidence_matrix(tree)

--- a/test/consensus.jl
+++ b/test/consensus.jl
@@ -1,7 +1,7 @@
 
 @testset "find_common_clusters" begin
-    ref_tree = parsing_newick_string("((A,(B,(C,(D,E)))),(F,(G,H)))")
-    tree2 = parsing_newick_string("((G,(C,(A,(F,E)))),(B,(D,H)))")
+    ref_tree = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
+    tree2 = ParseNewick("((G,(C,(A,(F,E)))),(B,(D,H)));")
     MCPhyloTree.number_nodes!.([ref_tree, tree2])
     MCPhyloTree.set_binary!.([ref_tree, tree2])
     A, B, C, D, E, F, G, H = find_by_name(tree2, "A"), find_by_name(tree2, "B"),
@@ -14,7 +14,7 @@
                            (D.num, (true, 1.0)), (E.num, (true, 1.0)), (F.num, (true, 1.0)), (G.num, (true, 1.0)), (H.num, (true, 1.0))])
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree2) , expected_dict)
 
-    tree3 = parsing_newick_string("((A,(C,(D,(B,E)))),(G,(F,H)))")
+    tree3 = ParseNewick("((A,(C,(D,(B,E)))),(G,(F,H)));")
     MCPhyloTree.number_nodes!(tree3)
     MCPhyloTree.set_binary!(tree3)
     A, B, C, D, E, F, G, H = find_by_name(tree3, "A"), find_by_name(tree3, "B"),
@@ -27,7 +27,7 @@
                            (D.num, (true, 1.0)), (E.num, (true, 1.0)), (F.num, (true, 1.0)), (G.num, (true, 1.0)), (H.num, (true, 1.0))])
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree3), expected_dict)
 
-    tree4 = parsing_newick_string("((A,(B,(C,(D,E)))),(F,(G,H)))")
+    tree4 = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
     MCPhyloTree.number_nodes!(tree4)
     MCPhyloTree.set_binary!(tree4)
     A, B, C, D, E, F, G, H = find_by_name(tree4, "A"), find_by_name(tree4, "B"),
@@ -40,28 +40,28 @@
                           (D.num, (true, 1.0)), (E.num, (true, 1.0)), (F.num, (true, 1.0)), (G.num, (true, 1.0)), (H.num, (true, 1.0))])
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree4), expected_dict)
 
-    tree5 = parsing_newick_string("((G,(X,(A,(F,E)))),(B,(D,H)))")
+    tree5 = ParseNewick("((G,(X,(A,(F,E)))),(B,(D,H)));")
     MCPhyloTree.number_nodes!(tree5)
     MCPhyloTree.set_binary!(tree5)
     @test_throws ArgumentError MCPhyloTree.find_common_clusters(ref_tree, tree5)
 
-    tree6 = parsing_newick_string("(X,(G,(C,(A,(F,E)))),(B,(D,H)))))")
+    tree6 = ParseNewick("(X,(G,(C,(A,(F,E)))),(B,(D,H)));")
     MCPhyloTree.number_nodes!(tree5)
     MCPhyloTree.set_binary!(tree5)
     @test_throws ArgumentError MCPhyloTree.find_common_clusters(ref_tree, tree6)
 end
 
 @testset "one_way_compatible" begin
-    tree = parsing_newick_string("((A,C,E),(B,D))")
-    tree2 = parsing_newick_string("((A,C),(B,D,E))")
-    expected_tree = parsing_newick_string("(A,C,E,(B,D))")
+    tree = ParseNewick("((A,C,E),(B,D));")
+    tree2 = ParseNewick("((A,C),(B,D,E));")
+    expected_tree = ParseNewick("(A,C,E,(B,D));")
     MCPhyloTree.number_nodes!.([tree, tree2, expected_tree])
     MCPhyloTree.set_binary!.([tree, tree2, expected_tree])
     @test newick(MCPhyloTree.one_way_compatible(tree, tree2)) == newick(expected_tree)
 end
 
 @testset "get_leaf_ranks" begin
-    ref_tree = parsing_newick_string("((A,(B,(C,(D,E)))),(F,(G,H)))")
+    ref_tree = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
     nodes = post_order(ref_tree)
     @test MCPhyloTree.get_leaf_ranks(nodes) == Dict([("A", 1), ("B", 2), ("C", 3),
                                                  ("D", 4), ("E", 5), ("F", 6),
@@ -69,7 +69,7 @@ end
 end
 
 @testset "order_tree!" begin
-    tree = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+    tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     A, B, C, D, E, F, G, H = find_by_name(tree, "A"), find_by_name(tree, "B"),
@@ -78,7 +78,7 @@ end
                              find_by_name(tree, "G"), find_by_name(tree, "H")
     cluster_start_indeces = Dict([(A, 3), (B, 7), (C, 2), (D, 8),
                                   (E, 5), (F, 1), (G, 4), (H, 6)])
-    ordered_tree = parsing_newick_string("(A,((E,D)F,C)G,B)H;")
+    ordered_tree = ParseNewick("(A,((E,D)F,C)G,B)H;")
     MCPhyloTree.number_nodes!(ordered_tree)
     MCPhyloTree.set_binary!(ordered_tree)
     @test MCPhyloTree.order_tree!(tree, cluster_start_indeces) == [A, E, D, C, B]
@@ -88,7 +88,7 @@ end
 end
 
 @testset "max/min_leaf_rank" begin
-    tree = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+    tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
     F, G, H, A = find_by_name(tree, "F"), find_by_name(tree, "G"),
                  find_by_name(tree, "H"), find_by_name(tree, "A")
     leaf_ranks = Dict([("A", 1), ("B", 5), ("C", 2), ("D", 4), ("E", 3)])
@@ -109,7 +109,7 @@ end
 end
 
 @testset "x_left_right" begin
-    tree = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+    tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     A, B, C, D, E, F, G, H = find_by_name(tree, "A"), find_by_name(tree, "B"),
@@ -135,63 +135,62 @@ end
 end
 
 @testset "majority_consensus_tree" begin
-    tree1 = parsing_newick_string("(((A,B),C),(D,E))")
-    tree2 = parsing_newick_string("((A,C),(B,D,E))")
-    tree3 = parsing_newick_string("(((B,C),A),D,E)")
+    tree1 = ParseNewick("(((A,B),C),(D,E));")
+    tree2 = ParseNewick("((A,C),(B,D,E));")
+    tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
     MCPhyloTree.number_nodes!.(trees)
     MCPhyloTree.set_binary!.(trees)
-    result = newick(parsing_newick_string("((A,B,C),D,E)"))
+    result = newick(ParseNewick("((A,B,C),D,E);"))
     @test newick(majority_consensus_tree(trees)) == result
 
-    tree4 = parsing_newick_string("(((B,C),A),D,F)")
+    tree4 = ParseNewick("(((B,C),A),D,F);")
     push!(trees, tree4)
     @test_throws ArgumentError majority_consensus_tree(trees)
 
-    tree1 = parsing_newick_string("(((A,B)AB,C)ABC,(D,E)DE)no_name;")
-    tree2 = parsing_newick_string("((A,C)AC,(B,D,E)BDE)no_name;")
-    tree3 = parsing_newick_string("(((B,C)BC,A)BCA,D,E)no_name;")
+    tree1 = ParseNewick("(((A,B)AB,C)ABC,(D,E)DE)no_name;")
+    tree2 = ParseNewick("((A,C)AC,(B,D,E)BDE)no_name;")
+    tree3 = ParseNewick("(((B,C)BC,A)BCA,D,E)no_name;")
     trees = [tree1, tree2, tree3]
     MCPhyloTree.number_nodes!.(trees)
     MCPhyloTree.set_binary!.(trees)
-    result = newick(parsing_newick_string("((A,B,C),D,E)"))
+    result = newick(ParseNewick("((A,B,C),D,E);"))
     @test newick(majority_consensus_tree(trees)) == result
 end
 
 @testset "loose_consensus_tree" begin
-    tree1 = parsing_newick_string("(((A,B),C),(D,E))")
-    tree2 = parsing_newick_string("((A,C),(B,D,E))")
-    tree3 = parsing_newick_string("(((B,C),A),D,E)")
+    tree1 = ParseNewick("(((A,B),C),(D,E));")
+    tree2 = ParseNewick("((A,C),(B,D,E));")
+    tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
     MCPhyloTree.number_nodes!.(trees)
     MCPhyloTree.set_binary!.(trees)
-    result = newick(parsing_newick_string("(A,B,C,(D,E))"))
+    result = newick(ParseNewick("(A,B,C,(D,E));"))
     @test newick(loose_consensus_tree(trees)) == result
 
-    tree4 = parsing_newick_string("(((B,C),A),D,F)")
+    tree4 = ParseNewick("(((B,C),A),D,F);")
     push!(trees, tree4)
     @test_throws ArgumentError loose_consensus_tree(trees)
-
-    tree1 = parsing_newick_string("(((A,B)AB,C)ABC,(D,E)DE)no_name;")
-    tree2 = parsing_newick_string("((A,C)AC,(B,D,E)BDE)no_name;")
-    tree3 = parsing_newick_string("(((B,C)BC,A)BCA,D,E)no_name;")
+    tree1 = ParseNewick("(((A,B)AB,C)ABC,(D,E)DE)no_name;")
+    tree2 = ParseNewick("((A,C)AC,(B,D,E)BDE)no_name;")
+    tree3 = ParseNewick("(((B,C)BC,A)BCA,D,E)no_name;")
     trees = [tree1, tree2, tree3]
     MCPhyloTree.number_nodes!.(trees)
     MCPhyloTree.set_binary!.(trees)
-    result = newick(parsing_newick_string("(A,B,C,(D,E)no_name)"))
+    result = newick(ParseNewick("(A,B,C,(D,E)no_name);"))
     @test newick(loose_consensus_tree(trees)) == result
 end
 
 @testset "greedy_consensus_tree" begin
-    tree1 = parsing_newick_string("(((A,B),C),(D,E))")
-    tree2 = parsing_newick_string("((A,C),(B,D,E))")
-    tree3 = parsing_newick_string("(((B,C),A),D,E)")
+    tree1 = ParseNewick("(((A,B),C),(D,E));")
+    tree2 = ParseNewick("((A,C),(B,D,E));")
+    tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
     MCPhyloTree.number_nodes!.(trees)
     MCPhyloTree.set_binary!.(trees)
-    result = newick(parsing_newick_string("(((A,B),C),(D,E))"))
-    # result = newick(parsing_newick_string("(((A,C),B),(D,E))"))
-    # result = newick(parsing_newick_string("(((B,C),A),(D,E))"))
+    result = newick(ParseNewick("(((A,B),C),(D,E));"))
+    # result = newick(ParseNewick("(((A,C),B),(D,E));"))
+    # result = newick(ParseNewick("(((B,C),A),(D,E));"))
     @test newick(greedy_consensus_tree(trees)) == result
 end
 
@@ -217,13 +216,3 @@ end
 
     @test MCPhyloTree.count_cluster_occurences(bit_vec) == queue
 end
-
-
-"""
-# Additional test with a big file of trees
-trees = ParseNewick("./doc/Tree/Drav_mytrees_1.nwk")
-MCPhyloTree.set_binary!.(trees)
-number_nodes!.(trees)
-majority_tree = majority_consensus_tree(trees)
-println(newick(majority_tree))
-"""

--- a/test/consensus.jl
+++ b/test/consensus.jl
@@ -2,8 +2,7 @@
 @testset "find_common_clusters" begin
     ref_tree = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
     tree2 = ParseNewick("((G,(C,(A,(F,E)))),(B,(D,H)));")
-    MCPhyloTree.number_nodes!.([ref_tree, tree2])
-    MCPhyloTree.set_binary!.([ref_tree, tree2])
+
     A, B, C, D, E, F, G, H = find_by_name(tree2, "A"), find_by_name(tree2, "B"),
                              find_by_name(tree2, "C"), find_by_name(tree2, "D"),
                              find_by_name(tree2, "E"), find_by_name(tree2, "F"),
@@ -15,8 +14,7 @@
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree2) , expected_dict)
 
     tree3 = ParseNewick("((A,(C,(D,(B,E)))),(G,(F,H)));")
-    MCPhyloTree.number_nodes!(tree3)
-    MCPhyloTree.set_binary!(tree3)
+    
     A, B, C, D, E, F, G, H = find_by_name(tree3, "A"), find_by_name(tree3, "B"),
                              find_by_name(tree3, "C"), find_by_name(tree3, "D"),
                              find_by_name(tree3, "E"), find_by_name(tree3, "F"),
@@ -28,8 +26,7 @@
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree3), expected_dict)
 
     tree4 = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
-    MCPhyloTree.number_nodes!(tree4)
-    MCPhyloTree.set_binary!(tree4)
+    
     A, B, C, D, E, F, G, H = find_by_name(tree4, "A"), find_by_name(tree4, "B"),
                              find_by_name(tree4, "C"), find_by_name(tree4, "D"),
                              find_by_name(tree4, "E"), find_by_name(tree4, "F"),
@@ -41,13 +38,11 @@
     @test isequal(MCPhyloTree.find_common_clusters(ref_tree, tree4), expected_dict)
 
     tree5 = ParseNewick("((G,(X,(A,(F,E)))),(B,(D,H)));")
-    MCPhyloTree.number_nodes!(tree5)
-    MCPhyloTree.set_binary!(tree5)
+    
     @test_throws ArgumentError MCPhyloTree.find_common_clusters(ref_tree, tree5)
 
     tree6 = ParseNewick("(X,(G,(C,(A,(F,E)))),(B,(D,H)));")
-    MCPhyloTree.number_nodes!(tree5)
-    MCPhyloTree.set_binary!(tree5)
+ 
     @test_throws ArgumentError MCPhyloTree.find_common_clusters(ref_tree, tree6)
 end
 
@@ -55,8 +50,7 @@ end
     tree = ParseNewick("((A,C,E),(B,D));")
     tree2 = ParseNewick("((A,C),(B,D,E));")
     expected_tree = ParseNewick("(A,C,E,(B,D));")
-    MCPhyloTree.number_nodes!.([tree, tree2, expected_tree])
-    MCPhyloTree.set_binary!.([tree, tree2, expected_tree])
+  
     @test newick(MCPhyloTree.one_way_compatible(tree, tree2)) == newick(expected_tree)
 end
 
@@ -70,8 +64,7 @@ end
 
 @testset "order_tree!" begin
     tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
+    
     A, B, C, D, E, F, G, H = find_by_name(tree, "A"), find_by_name(tree, "B"),
                              find_by_name(tree, "C"), find_by_name(tree, "D"),
                              find_by_name(tree, "E"), find_by_name(tree, "F"),
@@ -79,11 +72,7 @@ end
     cluster_start_indeces = Dict([(A, 3), (B, 7), (C, 2), (D, 8),
                                   (E, 5), (F, 1), (G, 4), (H, 6)])
     ordered_tree = ParseNewick("(A,((E,D)F,C)G,B)H;")
-    MCPhyloTree.number_nodes!(ordered_tree)
-    MCPhyloTree.set_binary!(ordered_tree)
     @test MCPhyloTree.order_tree!(tree, cluster_start_indeces) == [A, E, D, C, B]
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     @test newick(tree) == newick(ordered_tree)
 end
 
@@ -110,8 +99,7 @@ end
 
 @testset "x_left_right" begin
     tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
+    
     A, B, C, D, E, F, G, H = find_by_name(tree, "A"), find_by_name(tree, "B"),
                              find_by_name(tree, "C"), find_by_name(tree, "D"),
                              find_by_name(tree, "E"), find_by_name(tree, "F"),
@@ -139,8 +127,7 @@ end
     tree2 = ParseNewick("((A,C),(B,D,E));")
     tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
+    
     result = newick(ParseNewick("((A,B,C),D,E);"))
     @test newick(majority_consensus_tree(trees)) == result
 
@@ -152,8 +139,7 @@ end
     tree2 = ParseNewick("((A,C)AC,(B,D,E)BDE)no_name;")
     tree3 = ParseNewick("(((B,C)BC,A)BCA,D,E)no_name;")
     trees = [tree1, tree2, tree3]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
+    
     result = newick(ParseNewick("((A,B,C),D,E);"))
     @test newick(majority_consensus_tree(trees)) == result
 end
@@ -163,8 +149,7 @@ end
     tree2 = ParseNewick("((A,C),(B,D,E));")
     tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
+    
     result = newick(ParseNewick("(A,B,C,(D,E));"))
     @test newick(loose_consensus_tree(trees)) == result
 
@@ -175,8 +160,7 @@ end
     tree2 = ParseNewick("((A,C)AC,(B,D,E)BDE)no_name;")
     tree3 = ParseNewick("(((B,C)BC,A)BCA,D,E)no_name;")
     trees = [tree1, tree2, tree3]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
+    
     result = newick(ParseNewick("(A,B,C,(D,E)no_name);"))
     @test newick(loose_consensus_tree(trees)) == result
 end
@@ -186,8 +170,7 @@ end
     tree2 = ParseNewick("((A,C),(B,D,E));")
     tree3 = ParseNewick("(((B,C),A),D,E);")
     trees = [tree1, tree2, tree3]
-    MCPhyloTree.number_nodes!.(trees)
-    MCPhyloTree.set_binary!.(trees)
+    
     result = newick(ParseNewick("(((A,B),C),(D,E));"))
     # result = newick(ParseNewick("(((A,C),B),(D,E));"))
     # result = newick(ParseNewick("(((B,C),A),(D,E));"))

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,9 +1,9 @@
 
 @testset "dist RF" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
-    tree2 = parsing_newick_string("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
+    tree2 = ParseNewick("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     @test RF(tree, tree2) == 2
@@ -11,10 +11,10 @@ end
 
 
 @testset "dist RF_weighted" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
-    tree2 = parsing_newick_string("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
+    tree2 = ParseNewick("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
     MCPhyloTree.set_binary!(tree)
     MCPhyloTree.number_nodes!(tree)
     @test RF_weighted(tree, tree2) == 2/12

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -1,21 +1,13 @@
 
 @testset "dist RF" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     tree2 = ParseNewick("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     @test RF(tree, tree2) == 2
 end
 
 
 @testset "dist RF_weighted" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     tree2 = ParseNewick("((E:5.0,(B:5.0,A:5.0)C:9.0)F:5.0,D:5.0)G:5.0;")
-    MCPhyloTree.set_binary!(tree)
-    MCPhyloTree.number_nodes!(tree)
     @test RF_weighted(tree, tree2) == 2/12
 end

--- a/test/ladderize.jl
+++ b/test/ladderize.jl
@@ -1,8 +1,8 @@
 
 @testset "ladderize" begin
-    start_tree = parsing_newick_string("((A,(B,(C,(D,E)))),(F,(G,H)))")
-    descending_tree = parsing_newick_string("(((((D,E),C),B),A),((G,H),F))")
-    ascending_tree = parsing_newick_string("((F,(G,H)),(A,(B,(C,(D,E)))))")
+    start_tree = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
+    descending_tree = ParseNewick("(((((D,E),C),B),A),((G,H),F));")
+    ascending_tree = ParseNewick("((F,(G,H)),(A,(B,(C,(D,E)))));")
 
     start_newick = newick(start_tree)
     desc_newick = newick(descending_tree)
@@ -17,7 +17,7 @@
     ladderize_tree!(start_tree)
     @test newick(start_tree) == asc_newick
 
-    start_tree = parsing_newick_string("((A,(B,(C,(D,E)))),(F,(G,H)))")
+    start_tree = ParseNewick("((A,(B,(C,(D,E)))),(F,(G,H)));")
     ladderize_tree!(start_tree, false)
     @test newick(start_tree) == desc_newick
 end

--- a/test/moves.jl
+++ b/test/moves.jl
@@ -1,6 +1,6 @@
 
 @testset "swing" begin
-    tree = parsing_newick_string("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
+    tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
     MCPhyloTree.set_binary!(tree)
 
     MCPhyloTree.number_nodes!(tree)
@@ -17,7 +17,7 @@
 end
 
 @testset "slide" begin
-    tree = parsing_newick_string("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
+    tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
     MCPhyloTree.set_binary!(tree)
 
     MCPhyloTree.number_nodes!(tree)
@@ -35,7 +35,7 @@ end
 end
 
 @testset "NNI" begin
-    tree = parsing_newick_string("((I,J)A,(K,(M,N)L)B,(C,(O,P)E)G)H;")
+    tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,(O,P)E)G)H;")
     MCPhyloTree.set_binary!(tree)
 
     MCPhyloTree.number_nodes!(tree)
@@ -51,7 +51,7 @@ end
 end
 
 @testset "move" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     B = find_by_name(tree,"B")
     A = find_by_name(tree,"A")
     MCPhyloTree.move!(B,A,0.9)
@@ -60,7 +60,7 @@ end
 end
 
 @testset "change_edge_length" begin
-    tree = parsing_newick_string("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
+    tree = ParseNewick("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
     MCPhyloTree.number_nodes!(tree)
     change_edge_length!(tree)
     po_list = [x.inc_length for x in post_order(tree)]
@@ -68,14 +68,14 @@ end
 end
 
 @testset "reroot" begin
-    tree = parsing_newick_string("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
+    tree = ParseNewick("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
     MCPhyloTree.number_nodes!(tree)
     newtree = MCPhyloTree.reroot(tree,"C")
     @test newick(newtree) == "(B:1.0,A:1.0,((D:1.0,E:1.0)F:1.0)G:1.0)C:1.0;"
 end
 
 @testset "SPR" begin
-    tree2 = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+    tree2 = ParseNewick("(A,B,(C,(D,E)F)G)H;")
     MCPhyloTree.number_nodes!(tree2)
     MCPhyloTree.set_binary!(tree2)
     subtree = find_by_name(tree2,"F")

--- a/test/moves.jl
+++ b/test/moves.jl
@@ -1,9 +1,6 @@
 
 @testset "swing" begin
     tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
-    MCPhyloTree.set_binary!(tree)
-
-    MCPhyloTree.number_nodes!(tree)
 
     l = tree_length(tree)
 
@@ -18,9 +15,6 @@ end
 
 @testset "slide" begin
     tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,((O,P)D,E)F)G)H;")
-    MCPhyloTree.set_binary!(tree)
-
-    MCPhyloTree.number_nodes!(tree)
 
     l = tree_length(tree)
 
@@ -36,9 +30,7 @@ end
 
 @testset "NNI" begin
     tree = ParseNewick("((I,J)A,(K,(M,N)L)B,(C,(O,P)E)G)H;")
-    MCPhyloTree.set_binary!(tree)
 
-    MCPhyloTree.number_nodes!(tree)
     tr2 = deepcopy(tree)
 
     res = NNI!(tr2, 10, true)
@@ -61,7 +53,6 @@ end
 
 @testset "change_edge_length" begin
     tree = ParseNewick("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
-    MCPhyloTree.number_nodes!(tree)
     change_edge_length!(tree)
     po_list = [x.inc_length for x in post_order(tree)]
     @test sum(po_list) != 7.0
@@ -69,15 +60,12 @@ end
 
 @testset "reroot" begin
     tree = ParseNewick("((B:1,A:1)C:1,(D:1,E:1)F:1)G:1;")
-    MCPhyloTree.number_nodes!(tree)
     newtree = MCPhyloTree.reroot(tree,"C")
     @test newick(newtree) == "(B:1.0,A:1.0,((D:1.0,E:1.0)F:1.0)G:1.0)C:1.0;"
 end
 
 @testset "SPR" begin
     tree2 = ParseNewick("(A,B,(C,(D,E)F)G)H;")
-    MCPhyloTree.number_nodes!(tree2)
-    MCPhyloTree.set_binary!(tree2)
     subtree = find_by_name(tree2,"F")
     target = find_by_name(tree2,"A")
     nutree = MCPhyloTree.perform_spr(tree2,subtree,target)

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -1,11 +1,11 @@
 
-tree = parsing_newick_string("(A,B,(C,(D,E)F)G)H;")
+tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
 MCPhyloTree.number_nodes!(tree)
 
 @testset "Pruning leaf" begin
     node_list = ["C"]
     pt = prune_tree(tree, node_list)
-    @test newick(pt) == newick(parsing_newick_string("(A,B,((D,E)F)G)H;"))
+    @test newick(pt) == newick(ParseNewick("(A,B,((D,E)F)G)H;"))
 
     node_list = ["C", "C"]
     @test_throws ArgumentError prune_tree(tree, node_list)
@@ -15,7 +15,7 @@ MCPhyloTree.number_nodes!(tree)
 
     node_list = ["L", "C"]
     pt = prune_tree(tree, node_list)
-    @test newick(pt) == newick(parsing_newick_string("(A,B,((D,E)F)G)H;"))
+    @test newick(pt) == newick(ParseNewick("(A,B,((D,E)F)G)H;"))
 end
 
 @testset "Pruning root" begin
@@ -32,13 +32,13 @@ end
     prune_tree2 = prune_tree(tree, node_list2)
     prune_tree3 = prune_tree(tree, node_list3)
 
-    @test newick(prune_tree1) == newick(parsing_newick_string("(A,((D,E)F)G)H;"))
-    @test newick(prune_tree2) == newick(parsing_newick_string("(A,B,(C)G)H;"))
-    @test newick(prune_tree3) == newick(parsing_newick_string("(B)H;"))
+    @test newick(prune_tree1) == newick(ParseNewick("(A,((D,E)F)G)H;"))
+    @test newick(prune_tree2) == newick(ParseNewick("(A,B,(C)G)H;"))
+    @test newick(prune_tree3) == newick(ParseNewick("(B)H;"))
 end
 
 @testset "Pruning inplace" begin
     node_list1 = ["B", "C"]
     prune_tree!(tree, node_list1)
-    @test newick(tree) ==  newick(parsing_newick_string("(A,((D,E)F)G)H;"))
+    @test newick(tree) ==  newick(ParseNewick("(A,((D,E)F)G)H;"))
 end

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -1,6 +1,4 @@
-
 tree = ParseNewick("(A,B,(C,(D,E)F)G)H;")
-MCPhyloTree.number_nodes!(tree)
 
 @testset "Pruning leaf" begin
     node_list = ["C"]

--- a/test/search.jl
+++ b/test/search.jl
@@ -1,5 +1,5 @@
 @testset "search" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     result = find_num(tree,1)

--- a/test/search.jl
+++ b/test/search.jl
@@ -1,7 +1,5 @@
 @testset "search" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     result = find_num(tree,1)
     @test result.name == "A"
     leaf = find_by_name(tree,"E")

--- a/test/spr.jl
+++ b/test/spr.jl
@@ -1,11 +1,11 @@
 @testset "spr" begin
-    binary_tree = parsing_newick_string("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
+    binary_tree = ParseNewick("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
     MCPhyloTree.number_nodes!(binary_tree)
     MCPhyloTree.set_binary!(binary_tree)
 
-    error_tree = parsing_newick_string("(raccoon:19.19959):0.84600;")
-    error_tree_not_binary = parsing_newick_string("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300,lizard:5.03):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
-    tree_binary_two = parsing_newick_string("((raccoon:19.19959,bear:6.80041)50:0.84600,((sea_lion:11.99700,seal:12.00300)100:7.52973,((monkey:100.85930,cat:47.14069)80:20.59201,weasel:18.87953)75:2.09460)50:3.87382,dog:25.46154);")
+    error_tree = ParseNewick("(raccoon:19.19959):0.84600;")
+    error_tree_not_binary = ParseNewick("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300,lizard:5.03):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
+    tree_binary_two = ParseNewick("((raccoon:19.19959,bear:6.80041)50:0.84600,((sea_lion:11.99700,seal:12.00300)100:7.52973,((monkey:100.85930,cat:47.14069)80:20.59201,weasel:18.87953)75:2.09460)50:3.87382,dog:25.46154);")
 
     @test false == check_binary(error_tree)
     @test false == check_binary(error_tree_not_binary)

--- a/test/spr.jl
+++ b/test/spr.jl
@@ -1,7 +1,5 @@
 @testset "spr" begin
     binary_tree = ParseNewick("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
-    MCPhyloTree.number_nodes!(binary_tree)
-    MCPhyloTree.set_binary!(binary_tree)
 
     error_tree = ParseNewick("(raccoon:19.19959):0.84600;")
     error_tree_not_binary = ParseNewick("((raccoon:19.19959,bear:6.80041):0.84600,((sea_lion:11.99700,seal:12.00300,lizard:5.03):7.52973,((monkey:100.85930,cat:47.14069):20.59201,weasel:18.87953):2.09460):3.87382);")
@@ -18,8 +16,6 @@
     @test round(tree_length(binary_tree);digits=3) == round(tree_length(spr_binary);digits=3)
 
     @test length(post_order(spr_binary)) == length(post_order(binary_tree))
-
-    MCPhyloTree.number_nodes!(tree_binary_two)
 
     spr_binary_two = MCPhyloTree.SPR(tree_binary_two)
 

--- a/test/traversal.jl
+++ b/test/traversal.jl
@@ -1,5 +1,5 @@
 @testset "traversal" begin
-    tree = parsing_newick_string("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
+    tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
     MCPhyloTree.number_nodes!(tree)
     MCPhyloTree.set_binary!(tree)
     po_list = post_order(tree)

--- a/test/traversal.jl
+++ b/test/traversal.jl
@@ -1,7 +1,5 @@
 @testset "traversal" begin
     tree = ParseNewick("((B:5,A:5)C:9,(D:5,E:5)F:5)G:5;")
-    MCPhyloTree.number_nodes!(tree)
-    MCPhyloTree.set_binary!(tree)
     po_list = post_order(tree)
     retarray = []
     for x in po_list


### PR DESCRIPTION
Content:
- __*ParseNewick*__ is now the primary parsing function. *parsing_newick_string* is now an internal function and called by *ParseNewick*. 
    - As such *ParseNewick* now accepts filenames and newick strings as arguments.
- Update all tests to use *ParseNewick* instead of [*parsing_newick_string*  + *set_binary!* + *number_nodes!*] (much shorter now ;))
- group *number_nodes!*, *set_binary!* & *tree_height* in the *initialize_tree!* method. 
    - Includes a keyword argument to exclude *tree_height* to avoid unnecessarily computing the height multiple times in algorithms (e,g. in functions that compute the majority consensus tree)
    - Also add *update_tree!* (combining *set_binary!* & *tree_height*) with the same keyword argument
- update documentation to reflect these changes & inform the users on how / when to use *initialize_tree!* & *update_tree!*